### PR TITLE
Отвязка от gcc и небольшие изменения в addr.h

### DIFF
--- a/core/addr.h
+++ b/core/addr.h
@@ -17,21 +17,32 @@
 
 class Addr {
 public:
-  Addr(unsigned long long offs=0, unsigned long long seg=0) : _offset{offs}, _segment{seg}, _dirty{true} {}
+  Addr(unsigned long long offs=0, unsigned long long seg=0) 
+    : _offset{offs}, _segment{seg}, _dirty{true} { }
+  Addr(const Addr &rhs)            = default;
+  Addr& operator=(const Addr& rhs) = default;
+  virtual ~Addr()                  = default;
 
   unsigned long long offset() const { return _offset; }
   unsigned long long segment() const { return _segment; }
 
   bool compare(unsigned long long s) const { return _offset==s; }
 
+  //prefix cases
   Addr &operator++() { _offset++; _dirty = true; return*this;}
   Addr &operator--() { _offset--; _dirty = true; return*this;}
 
+  //postfix cases
+  Addr operator++(int) { Addr tmp(*this); operator++(); return tmp; }
+  Addr operator--(int) { Addr tmp(*this); operator--(); return tmp; }
+
+  Addr &operator+=(const Addr &rhs) { _offset += rhs.offset(); _dirty = true; return *this; }
+  Addr &operator-=(const Addr &rhs) { _offset -= rhs.offset(); _dirty = true; return *this; }
+
+  //TODO: consider case to change operation overloadings below (they are not 
+  //used currently) to functions i.e incOffset() :)
   Addr operator+(unsigned long long offs) const {return _offset+offs;}
   Addr operator-(unsigned long long offs) const {return _offset-offs;}
-  Addr operator-(const Addr &raddr) const { return _offset-raddr._offset; }
-  Addr operator+(const Addr &raddr) const { return _offset+raddr._offset; }
-
   Addr &operator+=(unsigned long long offs) { _offset+=offs; _dirty = true; return *this; }
   Addr &operator-=(unsigned long long offs) { _offset-=offs; _dirty = true; return *this; }
 
@@ -40,6 +51,8 @@ public:
 
   friend bool operator< (const Addr &lhs, const Addr &rhs);
   friend bool operator==(const Addr &lhs, const Addr &rhs);
+  friend Addr operator+ (Addr lhs, const Addr &rhs);
+  friend Addr operator- (Addr lhs, const Addr &rhs);
 
 private:
   unsigned long long _offset;
@@ -67,8 +80,9 @@ inline bool operator==(const Addr &lhs, const Addr &rhs) {
 }
 
 inline bool operator> (const Addr &lhs, const Addr &rhs) { return rhs < lhs; }
-inline bool operator>=(const Addr &lhs, const Addr &rhs) { return !(rhs < lhs);}
+inline bool operator>=(const Addr &lhs, const Addr &rhs) { return !(lhs < rhs);}
 inline bool operator<=(const Addr &lhs, const Addr &rhs) { return !(lhs > rhs); } 
 inline bool operator!=(const Addr &lhs, const Addr &rhs) { return !(lhs == rhs); }
-
+inline Addr operator- (Addr lhs, const Addr &rhs) { lhs -= rhs; return lhs; }
+inline Addr operator+ (Addr lhs, const Addr &rhs) { lhs += rhs; return lhs; }
 #endif

--- a/core/addr.h
+++ b/core/addr.h
@@ -23,13 +23,6 @@ public:
   unsigned long long segment() const { return _segment; }
 
   bool compare(unsigned long long s) const { return _offset==s; }
-  bool operator==(const Addr &s) const { return ((_offset==s._offset) && (_segment==s._segment)); }
-  bool operator!=(const Addr &s) const { return ((_offset!=s._offset) || (_segment!=s._segment)); }
-  ///@bug не учитывается сегмент в сравнениях больше/меньше
-  bool operator>=(const Addr &s) const { return ((_offset>=s._offset) && (_segment==s._segment)); }
-  bool operator<=(const Addr &s) const { return ((_offset<=s._offset) && (_segment==s._segment)); }
-  bool operator>(const Addr &s) const { return ((_offset>s._offset) && (_segment==s._segment)); }
-  bool operator<(const Addr &s) const { return ((_offset<s._offset) && (_segment==s._segment)); }
 
   Addr &operator++() { _offset++; _dirty = true; return*this;}
   Addr &operator--() { _offset--; _dirty = true; return*this;}
@@ -45,6 +38,9 @@ public:
   const std::string& toString() const;
   std::string offsetString() const;
 
+  friend bool operator< (const Addr &lhs, const Addr &rhs);
+  friend bool operator==(const Addr &lhs, const Addr &rhs);
+
 private:
   unsigned long long _offset;
   unsigned long long _segment;
@@ -52,5 +48,27 @@ private:
   mutable std::string _hex_cache;
   mutable bool _dirty;
 };
+
+//idiomatic way -- http://en.cppreference.com/w/cpp/language/operators
+//example -- https://github.com/llvm-mirror/libcxx/blob/master/include/tuple#L949
+///@bug не учитывается сегмент в сравнениях больше/меньше
+inline bool operator<(const Addr &lhs, const Addr &rhs) {
+  if (lhs.segment() != rhs.segment())
+    return false;
+
+  return lhs._offset < rhs._offset;
+}
+
+inline bool operator==(const Addr &lhs, const Addr &rhs) {
+  if (lhs.segment() != rhs.segment())
+    return false;
+
+  return lhs._offset == rhs._offset;
+}
+
+inline bool operator> (const Addr &lhs, const Addr &rhs) { return rhs < lhs; }
+inline bool operator>=(const Addr &lhs, const Addr &rhs) { return !(rhs < lhs);}
+inline bool operator<=(const Addr &lhs, const Addr &rhs) { return !(lhs > rhs); } 
+inline bool operator!=(const Addr &lhs, const Addr &rhs) { return !(lhs == rhs); }
 
 #endif

--- a/core/addr.h
+++ b/core/addr.h
@@ -17,16 +17,18 @@
 
 class Addr {
 public:
-  Addr(unsigned long long offs=0, unsigned long long seg=0) 
+  using addr_t = unsigned long long;
+
+  Addr(addr_t offs = 0, addr_t seg = 0) 
     : _offset{offs}, _segment{seg}, _dirty{true} { }
   Addr(const Addr &rhs)            = default;
   Addr& operator=(const Addr& rhs) = default;
   virtual ~Addr()                  = default;
 
-  unsigned long long offset() const { return _offset; }
-  unsigned long long segment() const { return _segment; }
+  addr_t offset() const { return _offset; }
+  addr_t segment() const { return _segment; }
 
-  bool compare(unsigned long long s) const { return _offset==s; }
+  bool compare(addr_t s) const { return _offset==s; }
 
   //prefix cases
   Addr &operator++() { _offset++; _dirty = true; return*this;}
@@ -39,12 +41,12 @@ public:
   Addr &operator+=(const Addr &rhs) { _offset += rhs.offset(); _dirty = true; return *this; }
   Addr &operator-=(const Addr &rhs) { _offset -= rhs.offset(); _dirty = true; return *this; }
 
-  //TODO: consider case to change operation overloadings below (they are not 
-  //used currently) to functions i.e incOffset() :)
-  Addr operator+(unsigned long long offs) const {return _offset+offs;}
-  Addr operator-(unsigned long long offs) const {return _offset-offs;}
-  Addr &operator+=(unsigned long long offs) { _offset+=offs; _dirty = true; return *this; }
-  Addr &operator-=(unsigned long long offs) { _offset-=offs; _dirty = true; return *this; }
+  //TODO: consider case to change operation overloadings below (are not used 
+  //currently) to functions i.e incOffset() :)
+  Addr operator+(addr_t offs) const {return _offset+offs;}
+  Addr operator-(addr_t offs) const {return _offset-offs;}
+  Addr &operator+=(addr_t offs) { _offset+=offs; _dirty = true; return *this; }
+  Addr &operator-=(addr_t offs) { _offset-=offs; _dirty = true; return *this; }
 
   const std::string& toString() const;
   std::string offsetString() const;
@@ -55,8 +57,8 @@ public:
   friend Addr operator- (Addr lhs, const Addr &rhs);
 
 private:
-  unsigned long long _offset;
-  unsigned long long _segment;
+  addr_t _offset;
+  addr_t _segment;
 ///@todo не всегда нужен кэш строки... Может стоит разбить на 2 класса
   mutable std::string _hex_cache;
   mutable bool _dirty;

--- a/core/utils.h
+++ b/core/utils.h
@@ -4,8 +4,8 @@
 #include <iomanip>
 #include <sstream>
 #include <algorithm>
-#include <ctype.h>
-
+#include <cctype>
+#include <vector>
 #include <iostream>
 
 extern std::string _hex[256];

--- a/gui/disassembler_widget.h
+++ b/gui/disassembler_widget.h
@@ -45,7 +45,8 @@ private:
 
   void printReferences(QTextCursor &cursor, std::shared_ptr<GUIChunk> chunk);
   void printCommand(QTextCursor &cursor, const Command &cmd);
-  void __attribute__ ((deprecated)) printChunkUnparsed(QTextCursor &cursor, std::shared_ptr<GUIChunk> chunk);
+  //C++14 atributes -- http://en.cppreference.com/w/cpp/language/attributes
+  [[deprecated]] void printChunkUnparsed(QTextCursor &cursor, std::shared_ptr<GUIChunk> chunk);
   void printChunkCode(QTextCursor &cursor, std::shared_ptr<GUIChunk> chunk);
 
   void navigateToAddrDlg();


### PR DESCRIPTION
Небольшие изменения.
1) отвязались от гццизма с использованием атрибутов (в данном случае использовался deprecated). С++14 вводит до. атрибуты, включая deprecated -- http://en.cppreference.com/w/cpp/language/attributes
2) Расово верные и бого угодные перегрузки операторов в addr.h -- ссылки в комментариях. Срач приветствуется :3
